### PR TITLE
[codex] fix casino game rules and blackjack options

### DIFF
--- a/casino/baccarat.py
+++ b/casino/baccarat.py
@@ -79,6 +79,7 @@ class BaccaratRoom:
     MAX_PLAYERS = 20
     BETTING_TIMEOUT = 60
     ROUND_END_TIMEOUT = 60
+    BET_GRANULARITY = 20
 
     def __init__(self, ctx: commands.Context, cog, min_bet: int):
         self.ctx = ctx
@@ -167,6 +168,8 @@ class BaccaratRoom:
                 return False, "目前不是下注階段。"
             if amount < self.min_bet:
                 return False, f"最低下注為 {self.min_bet:,} 狗幣。"
+            if amount % self.BET_GRANULARITY != 0:
+                return False, f"下注金額必須為 {self.BET_GRANULARITY:,} 的倍數，才能正確計算莊家 5% 佣金。"
 
             existing = self.bets.get(member.id)
             if existing is None and len(self.bets) >= self.MAX_PLAYERS:
@@ -577,7 +580,7 @@ class BaccaratBetModal(discord.ui.Modal):
         self.bet_type = bet_type
         self.amount_input = discord.ui.TextInput(
             label="下注金額",
-            placeholder=f"請輸入整數，最低 {room.min_bet}",
+            placeholder=f"請輸入整數，最低 {room.min_bet}，且為 {room.BET_GRANULARITY} 的倍數",
             required=True,
             style=discord.TextStyle.short,
             max_length=12,

--- a/casino/blackjack.py
+++ b/casino/blackjack.py
@@ -1,38 +1,57 @@
-import discord
-from redbot.core import commands
-import random
 import logging
+import random
+from decimal import Decimal, ROUND_HALF_UP
 from typing import List, Optional, Union
 
-# 全域牌組模板
-RANKS = ['2', '3', '4', '5', '6', '7', '8', '9', 'J', 'Q', 'K', 'A']
+import discord
+from redbot.core import commands
+
+
+RANKS = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A']
 SUITS = ['♠', '♥', '♦', '♣']
 
 log = logging.getLogger("red.BadwolfCogs.casino.Blackjack")
 
+
 class BlackjackGame:
+    DECK_COUNT = 8
+
     def __init__(
         self,
         ctx: Union[commands.Context, discord.Interaction],
         cog,
         bet: int,
     ):
-        # 初始時必填 ctx（Context 或者 Interaction）
         self.ctx = ctx
         self.cog = cog
         self.bet = bet
-        self.player_hand: List[str] = []
-        self.dealer_hand: List[str] = []
         self.deck: List[str] = []
+        self.dealer_hand: List[str] = []
+        self.player_hands: List[List[str]] = []
+        self.hand_bets: List[int] = []
+        self.hand_doubled: List[bool] = []
+        self.hand_done: List[bool] = []
+        self.hand_results: List[Optional[dict]] = []
+        self.current_hand_index = 0
+        self.split_performed = False
+
         self.message: Optional[discord.Message] = None
-        self.doubled = False
-        #賠率
-        self.blackjack_payout_multiplier = 1.5
-        self.double_win_multiplier = 2.0
-        self.five_card_charlie_payout_multiplier = 2.0
+        self.view: Optional[BlackjackView] = None
+        self.phase = "playing"
+        self._finalized = False
+
+        self.blackjack_payout_multiplier = Decimal("1.5")
+        self.five_card_charlie_payout_multiplier = Decimal("2.0")
+        self.insurance_bet = 0
+        self.insurance_profit = 0
+        self.insurance_settled = False
+
+    @property
+    def current_hand(self) -> List[str]:
+        return self.player_hands[self.current_hand_index]
 
     def build_deck(self) -> None:
-        self.deck = [f"{s}{r}" for s in SUITS for r in RANKS]
+        self.deck = [f"{s}{r}" for _ in range(self.DECK_COUNT) for s in SUITS for r in RANKS]
         random.shuffle(self.deck)
 
     def draw(self) -> str:
@@ -41,21 +60,72 @@ class BlackjackGame:
         return self.deck.pop()
 
     @staticmethod
-    def value_of(card: str) -> int:
-        r = card[-1]
-        if r in 'JQK':
+    def rank_of(card: str) -> str:
+        return card[1:]
+
+    @classmethod
+    def value_of(cls, card: str) -> int:
+        rank = cls.rank_of(card)
+        if rank in {'J', 'Q', 'K'}:
             return 10
-        if r == 'A':
+        if rank == 'A':
             return 11
-        return int(r)
+        return int(rank)
 
     def calc_total(self, hand: List[str]) -> int:
         total = sum(self.value_of(c) for c in hand)
-        aces = sum(1 for c in hand if c[-1] == 'A')
+        aces = sum(1 for c in hand if self.rank_of(c) == 'A')
         while total > 21 and aces:
             total -= 10
             aces -= 1
         return total
+
+    def round_payout(self, bet: int, multiplier: Decimal) -> int:
+        return int((Decimal(bet) * multiplier).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+    def is_natural_blackjack(self, hand: List[str]) -> bool:
+        return len(hand) == 2 and self.calc_total(hand) == 21
+
+    def dealer_has_blackjack(self) -> bool:
+        return self.is_natural_blackjack(self.dealer_hand)
+
+    def dealer_shows_ace(self) -> bool:
+        return bool(self.dealer_hand) and self.rank_of(self.dealer_hand[0]) == 'A'
+
+    def insurance_amount(self) -> int:
+        return self.bet // 2
+
+    async def start(self, ctx: Union[commands.Context, discord.Interaction] = None):
+        if ctx is not None:
+            self.ctx = ctx
+
+        await self.cog.update_balance(self.ctx.author, -self.bet)
+        self.build_deck()
+        self._finalized = False
+        self.phase = "insurance" if self.dealer_shows_ace() else "playing"
+        self.split_performed = False
+        self.current_hand_index = 0
+        self.insurance_bet = 0
+        self.insurance_profit = 0
+        self.insurance_settled = False
+
+        self.player_hands = [[self.draw(), self.draw()]]
+        self.dealer_hand = [self.draw(), self.draw()]
+        self.hand_bets = [self.bet]
+        self.hand_doubled = [False]
+        self.hand_done = [False]
+        self.hand_results = [None]
+
+        self.phase = "insurance" if self.dealer_shows_ace() else "playing"
+        self.view = BlackjackView(self)
+        self.message = await self.ctx.reply(
+            embed=self.embed("🎴 **Blackjack 21點** 🎴", self.build_description()),
+            view=self.view,
+            mention_author=False,
+        )
+
+        if self.phase == "playing":
+            await self.resolve_initial_blackjacks()
 
     def embed(self, title: str, desc: str, win: Optional[bool] = None) -> discord.Embed:
         if win is True:
@@ -66,106 +136,296 @@ class BlackjackGame:
             color = discord.Color.dark_grey()
         return discord.Embed(title=title, description=desc, color=color)
 
-    async def start(self, ctx: Union[commands.Context, discord.Interaction] = None):
-        """開始遊戲。可選傳入新的 Context/Interaction 來覆寫 self.ctx。"""
-        if ctx is not None:
-            self.ctx = ctx  # 支援 on_message 的 interaction 或 command ctx
+    def can_take_insurance(self) -> bool:
+        return self.phase == "insurance" and self.insurance_amount() > 0 and self.insurance_bet == 0
 
-        # 扣款與初始牌，顯示下注
-        await self.cog.update_balance(self.ctx.author, -self.bet)
-        self.build_deck()
-        self.doubled = False
-        self.player_hand = [self.draw(), self.draw()]
-        self.dealer_hand = [self.draw(), self.draw()]
+    def can_split_current_hand(self) -> bool:
+        if self.phase != "playing" or self.split_performed:
+            return False
+        hand = self.current_hand
+        return len(hand) == 2 and self.value_of(hand[0]) == self.value_of(hand[1])
+
+    def can_double_current_hand(self) -> bool:
+        if self.phase != "playing" or self.split_performed:
+            return False
+        return len(self.current_hand) == 2 and not self.hand_doubled[self.current_hand_index]
+
+    async def has_balance_for_extra_bet(self, amount: int) -> bool:
+        return await self.cog.get_balance(self.ctx.author) >= amount
+
+    async def update_message(self, notice: str = ""):
+        if self._finalized or not self.message:
+            return
         self.view = BlackjackView(self)
-        
-
-        desc = (
-            "━━━━━━━━━━━━━━━━━━━━\n"
-            f"🪙 本輪下注：{self.bet:,} 狗幣\n\n"
-            f"🧑 你的手牌：\n"
-            f"{'  '.join(self.player_hand)}\n"
-            f"🧮 玩家點數：**{self.calc_total(self.player_hand)}**\n\n"
-            f"🃏 莊家的手牌：\n"
-            f"{self.dealer_hand[0]}  ??\n"
-            "━━━━━━━━━━━━━━━━━━━━"
+        await self.message.edit(
+            embed=self.embed("🎴 **Blackjack 21點** 🎴", self.build_description(notice=notice)),
+            view=self.view,
         )
-        view = BlackjackView(self)
-        embed = self.embed("🎴 **Blackjack 21點** 🎴", desc)
-        self.message = await self.ctx.reply(embed=embed, view=self.view, mention_author=False)
 
-        blackjack_result = await self.check_blackjack()
-        if blackjack_result:
-            if blackjack_result == "push":
-                await self.finalize("雙方皆為 Blackjack，平手退還下注。", win=None)
-            elif blackjack_result == "player":
-                payout = int(self.bet * self.blackjack_payout_multiplier)
-                await self.finalize("玩家擁有自然 Blackjack，獲勝！", win=True, payout=payout)
-            elif blackjack_result == "dealer":
-                await self.finalize("莊家擁有自然 Blackjack，你輸了。", win=False)
+    def build_description(self, reveal_dealer: bool = False, notice: str = "") -> str:
+        lines = [
+            "━━━━━━━━━━━━━━━━━━━━",
+            f"🪙 本輪下注：{sum(self.hand_bets) + self.insurance_bet:,} 狗幣",
+            f"規則：{self.DECK_COUNT} 副牌｜Blackjack 3:2 四捨五入｜莊家 Soft 17 停牌｜Split 一次",
+        ]
+        if self.insurance_bet:
+            lines.append(f"🛡️ 保險下注：{self.insurance_bet:,} 狗幣")
+        if notice:
+            lines.append(f"📢 {notice}")
+
+        lines.extend(["", "🧑 你的手牌："])
+        for idx, hand in enumerate(self.player_hands):
+            marker = "▶ " if idx == self.current_hand_index and not self.hand_done[idx] and self.phase == "playing" else ""
+            result = self.hand_results[idx]
+            status = result["label"] if result else ("等待莊家結算" if self.hand_done[idx] else "進行中")
+            doubled = "｜已雙倍" if self.hand_doubled[idx] else ""
+            lines.append(
+                f"{marker}手牌 {idx + 1}：{'  '.join(hand)}（{self.calc_total(hand)}）"
+                f"｜下注 {self.hand_bets[idx]:,}{doubled}｜{status}"
+            )
+
+        dealer_cards = "  ".join(self.dealer_hand) if reveal_dealer else f"{self.dealer_hand[0]}  ??"
+        dealer_total = self.calc_total(self.dealer_hand) if reveal_dealer else "?"
+        lines.extend([
+            "",
+            "🃏 莊家的手牌：",
+            dealer_cards,
+            f"🧮 莊家點數：**{dealer_total}**",
+            "━━━━━━━━━━━━━━━━━━━━",
+        ])
+        return "\n".join(lines)
+
+    async def resolve_initial_blackjacks(self, notice: str = ""):
+        if self._finalized:
             return
 
-    async def check_blackjack(self) -> Optional[str]:
-        """檢查是否有人擁有自然 Blackjack。"""
-        p_blackjack = self.calc_total(self.player_hand) == 21 and len(self.player_hand) == 2
-        d_blackjack = self.calc_total(self.dealer_hand) == 21 and len(self.dealer_hand) == 2
+        dealer_blackjack = self.dealer_has_blackjack()
+        player_blackjack = self.is_natural_blackjack(self.player_hands[0])
+        self.settle_insurance(dealer_blackjack)
 
-        if p_blackjack and d_blackjack:
-            return "push"
-        elif p_blackjack:
-            return "player"
-        elif d_blackjack:
-            return "dealer"
-        return None
-    
-    async def finalize(self, result: str, win: Optional[bool] = None, payout: int = 0):
-        """當玩家停牌或爆牌後的最終結算。"""
-        total_bet = self.bet * (2 if self.doubled else 1)
+        if dealer_blackjack:
+            if player_blackjack:
+                self.hand_results[0] = {"profit": 0, "label": "Blackjack 平手"}
+            else:
+                self.hand_results[0] = {"profit": -self.hand_bets[0], "label": "莊家 Blackjack"}
+            self.hand_done[0] = True
+            await self.finalize("莊家 Blackjack。")
+            return
 
-        if win is True:
-            total_gain = total_bet + payout  # 包含下注本金與贏得的獎金
-            await self.cog.update_balance(self.ctx.author, total_gain)
-            round_delta = payout
-        elif win is None:
-            await self.cog.update_balance(self.ctx.author, total_bet)  # 平手退回本金
-            round_delta = 0
-        else:
-            round_delta = -total_bet
-            
+        if player_blackjack:
+            payout = self.round_payout(self.hand_bets[0], self.blackjack_payout_multiplier)
+            self.hand_results[0] = {"profit": payout, "label": "自然 Blackjack"}
+            self.hand_done[0] = True
+            await self.finalize("玩家擁有自然 Blackjack，獲勝！")
+            return
+
+        await self.update_message(notice)
+
+    def settle_insurance(self, dealer_blackjack: bool):
+        if self.insurance_settled:
+            return
+        if self.insurance_bet:
+            self.insurance_profit = self.insurance_bet * 2 if dealer_blackjack else -self.insurance_bet
+        self.insurance_settled = True
+
+    async def take_insurance(self):
+        amount = self.insurance_amount()
+        if amount <= 0:
+            await self.update_message("目前下注無法購買保險。")
+            return
+        if not await self.has_balance_for_extra_bet(amount):
+            await self.update_message("餘額不足，無法購買保險。")
+            return
+
+        await self.cog.update_balance(self.ctx.author, -amount)
+        self.insurance_bet = amount
+        self.phase = "playing"
+        await self.resolve_initial_blackjacks("已購買保險。")
+
+    async def decline_insurance(self):
+        self.phase = "playing"
+        await self.resolve_initial_blackjacks("未購買保險。")
+
+    async def take_even_money(self):
+        self.hand_results[0] = {"profit": self.bet, "label": "Even Money"}
+        self.hand_done[0] = True
+        self.phase = "playing"
+        self.insurance_settled = True
+        await self.finalize("玩家選擇 Even Money，獲得 1:1 派彩。")
+
+    async def decline_even_money(self):
+        self.phase = "playing"
+        await self.resolve_initial_blackjacks("未選擇 Even Money。")
+
+    async def hit_current_hand(self):
+        hand = self.current_hand
+        hand.append(self.draw())
+        total = self.calc_total(hand)
+
+        if total > 21:
+            stake = self.hand_bets[self.current_hand_index]
+            self.hand_results[self.current_hand_index] = {"profit": -stake, "label": "爆牌"}
+            self.hand_done[self.current_hand_index] = True
+            await self.finish_turn("你爆牌了。")
+            return
+
+        if len(hand) >= 5:
+            stake = self.hand_bets[self.current_hand_index]
+            payout = self.round_payout(stake, self.five_card_charlie_payout_multiplier)
+            self.hand_results[self.current_hand_index] = {"profit": payout, "label": "五龍勝利"}
+            self.hand_done[self.current_hand_index] = True
+            await self.finish_turn("五龍勝利。")
+            return
+
+        await self.update_message()
+
+    async def stand_current_hand(self, notice: str = "停牌。"):
+        self.hand_done[self.current_hand_index] = True
+        await self.finish_turn(notice)
+
+    async def double_current_hand(self):
+        if not self.can_double_current_hand():
+            await self.update_message("目前不能雙倍下注。")
+            return
+        if not await self.has_balance_for_extra_bet(self.bet):
+            await self.update_message("餘額不足，無法雙倍下注。")
+            return
+
+        await self.cog.update_balance(self.ctx.author, -self.bet)
+        idx = self.current_hand_index
+        self.hand_bets[idx] += self.bet
+        self.hand_doubled[idx] = True
+        self.player_hands[idx].append(self.draw())
+
+        total = self.calc_total(self.player_hands[idx])
+        if total > 21:
+            self.hand_results[idx] = {"profit": -self.hand_bets[idx], "label": "雙倍後爆牌"}
+        self.hand_done[idx] = True
+        await self.finish_turn("已雙倍下注。")
+
+    async def split_current_hand(self):
+        if not self.can_split_current_hand():
+            await self.update_message("目前不能分牌。")
+            return
+        if not await self.has_balance_for_extra_bet(self.bet):
+            await self.update_message("餘額不足，無法分牌。")
+            return
+
+        await self.cog.update_balance(self.ctx.author, -self.bet)
+        first, second = self.current_hand
+        self.player_hands = [[first, self.draw()], [second, self.draw()]]
+        self.hand_bets = [self.bet, self.bet]
+        self.hand_doubled = [False, False]
+        self.hand_done = [False, False]
+        self.hand_results = [None, None]
+        self.current_hand_index = 0
+        self.split_performed = True
+        await self.update_message("已分牌。")
+
+    async def finish_turn(self, notice: str = ""):
+        if self._finalized:
+            return
+
+        for idx in range(self.current_hand_index + 1, len(self.player_hands)):
+            if not self.hand_done[idx]:
+                self.current_hand_index = idx
+                await self.update_message(notice)
+                return
+
+        if any(result is None for result in self.hand_results):
+            self.play_dealer_hand()
+            self.settle_stood_hands()
+
+        await self.finalize(notice or "遊戲結束。")
+
+    def play_dealer_hand(self):
+        while self.calc_total(self.dealer_hand) < 17:
+            self.dealer_hand.append(self.draw())
+
+    def settle_stood_hands(self):
+        dealer_total = self.calc_total(self.dealer_hand)
+        for idx, result in enumerate(self.hand_results):
+            if result is not None:
+                continue
+
+            player_total = self.calc_total(self.player_hands[idx])
+            stake = self.hand_bets[idx]
+            if dealer_total > 21 or player_total > dealer_total:
+                self.hand_results[idx] = {"profit": stake, "label": "勝利"}
+            elif player_total == dealer_total:
+                self.hand_results[idx] = {"profit": 0, "label": "平手"}
+            else:
+                self.hand_results[idx] = {"profit": -stake, "label": "落敗"}
+            self.hand_done[idx] = True
+
+    async def resolve_timeout(self):
+        if self._finalized:
+            return
+
+        if self.phase == "insurance":
+            self.phase = "playing"
+            await self.resolve_initial_blackjacks("保險 / Even Money 選擇逾時。")
+            return
+
+        for idx, done in enumerate(self.hand_done):
+            if not done:
+                self.hand_done[idx] = True
+        await self.finish_turn("超時停牌。")
+
+    async def finalize(self, result: str):
+        if self._finalized:
+            log.warning(f"Attempted to finalize already finished blackjack game for {self.ctx.author.id}")
+            return
+        self._finalized = True
+
+        if self.insurance_bet and not self.insurance_settled:
+            self.settle_insurance(self.dealer_has_blackjack())
+
+        total_bet = sum(self.hand_bets) + self.insurance_bet
+        hand_profit = sum(result_data["profit"] for result_data in self.hand_results if result_data)
+        total_profit = hand_profit + self.insurance_profit
+
+        return_amount = 0
+        for stake, result_data in zip(self.hand_bets, self.hand_results):
+            profit = result_data["profit"] if result_data else -stake
+            if profit >= 0:
+                return_amount += stake + profit
+        if self.insurance_bet and self.insurance_profit >= 0:
+            return_amount += self.insurance_bet + self.insurance_profit
+
+        if return_amount > 0:
+            await self.cog.update_balance(self.ctx.author, return_amount)
+
         await self.cog.stats_db.update_stats(
             self.ctx.author.id,
             game_type="blackjack",
             bet=total_bet,
-            profit=round_delta
+            profit=total_profit,
         )
 
         total_balance = await self.cog.get_balance(self.ctx.author)
+        insurance_line = ""
+        if self.insurance_bet:
+            insurance_line = f"🛡️ 保險盈虧：{self.insurance_profit:+,} 狗幣\n"
+
         desc = (
-            "━━━━━━━━━━━━━━━━━━━━\n"
-            f"🪙 本輪下注: {total_bet} 狗幣\n\n"
-            f"🧑 你的手牌：\n"
-            f"{'  '.join(self.player_hand)}\n"
-            f"🧮 玩家點數：**{self.calc_total(self.player_hand)}**\n\n"
-            f"🃏 莊家的手牌：\n"
-            f"{'  '.join(self.dealer_hand)}\n"
-            f"🧮 莊家點數：**{self.calc_total(self.dealer_hand)}**\n\n"
+            f"{self.build_description(reveal_dealer=True)}\n"
             f"📢 結果：{result}\n"
-            f"💰 本輪盈虧：{round_delta:+,} 狗幣\n"
+            f"{insurance_line}"
+            f"💰 本輪盈虧：{total_profit:+,} 狗幣\n"
             f"💼 目前總餘額：{int(total_balance):,} 狗幣\n"
             "━━━━━━━━━━━━━━━━━━━━"
         )
-        embed = self.embed("🏁 **遊戲結束** 🏁", desc, win)
+        embed = self.embed("🏁 **遊戲結束** 🏁", desc, total_profit > 0 if total_profit != 0 else None)
         if self.message:
             await self.message.edit(embed=embed, view=None)
         else:
             await self.ctx.send(embed=embed)
         self.cleanup()
 
-
     def cleanup(self):
-        """遊戲結束時呼叫：移除 active_games 鎖定"""
         self.cog.end_game(self.ctx.author.id)
-        if hasattr(self, 'view'):
+        if self.view:
             self.view.stop()
 
 
@@ -173,107 +433,83 @@ class BlackjackView(discord.ui.View):
     def __init__(self, game: BlackjackGame):
         super().__init__(timeout=60)
         self.game = game
-        # 初始化時處理雙倍下注按鈕是否可用
-        for item in self.children:
-            if getattr(item, 'custom_id', None) == 'double':
-                total = self.game.calc_total(self.game.player_hand)
-                item.disabled = not (len(self.game.player_hand) == 2)
+
+        if game.phase == "insurance":
+            self.remove_item(self.hit)
+            self.remove_item(self.stand)
+            self.remove_item(self.double)
+            self.remove_item(self.split)
+            if game.is_natural_blackjack(game.player_hands[0]):
+                self.remove_item(self.insurance)
+                self.remove_item(self.no_insurance)
+            else:
+                self.remove_item(self.even_money)
+                self.remove_item(self.decline_even_money)
+                if not game.can_take_insurance():
+                    self.insurance.disabled = True
+        else:
+            self.remove_item(self.insurance)
+            self.remove_item(self.no_insurance)
+            self.remove_item(self.even_money)
+            self.remove_item(self.decline_even_money)
+            self.double.disabled = not game.can_double_current_hand()
+            self.split.disabled = not game.can_split_current_hand()
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user != self.game.ctx.author:
             await interaction.response.send_message("這不是你的遊戲！", ephemeral=True)
             return False
+        if self.game._finalized:
+            await interaction.response.send_message("遊戲已經結束。", ephemeral=True)
+            return False
         return True
 
     @discord.ui.button(label="叫牌", style=discord.ButtonStyle.green, custom_id="hit")
     async def hit(self, interaction: discord.Interaction, button: discord.ui.Button):
-        self.game.player_hand.append(self.game.draw())
-        total = self.game.calc_total(self.game.player_hand)
-        if total > 21:
-            await self.game.finalize("你爆牌了！", win=False)
-            self.stop()
-        elif len(self.game.player_hand) >= 5 and total <= 21:
-            payout = int(self.game.bet * self.game.five_card_charlie_payout_multiplier)
-            await self.game.finalize(f"五龍勝利！", win=True, payout=payout)
-            self.stop()
-        else:
-            desc = (
-                "━━━━━━━━━━━━━━━━━━━━\n"
-                f"🪙 本輪下注：{self.game.bet:,} 狗幣\n\n"
-                f"🧑 你的手牌：\n"
-                f"{'  '.join(self.game.player_hand)}\n"
-                f"🧮 玩家點數：**{self.game.calc_total(self.game.player_hand)}**\n\n"
-                f"🃏 莊家的手牌：\n"
-                f"{self.game.dealer_hand[0]}  ??\n"
-                "━━━━━━━━━━━━━━━━━━━━"
-            )
-            await interaction.response.edit_message(embed=self.game.embed("21 點遊戲", desc), view=self)
+        await interaction.response.defer()
+        await self.game.hit_current_hand()
 
     @discord.ui.button(label="停牌", style=discord.ButtonStyle.grey, custom_id="stand")
     async def stand(self, interaction: discord.Interaction, button: discord.ui.Button):
-        await self.dealer_play(interaction)
-        self.stop()
+        await interaction.response.defer()
+        await self.game.stand_current_hand()
 
     @discord.ui.button(label="雙倍下注", style=discord.ButtonStyle.blurple, custom_id="double")
     async def double(self, interaction: discord.Interaction, button: discord.ui.Button):
-        if self.game.doubled:
-            await interaction.response.send_message("已執行雙倍下注！", ephemeral=True)
-            return
-        bal = await self.game.cog.get_balance(self.game.ctx.author)
-        if bal < self.game.bet:
-            await interaction.response.send_message("餘額不足，無法雙倍下注！", ephemeral=True)
-            return
-        
-        if len(self.game.player_hand) != 2:
-            await interaction.response.send_message("只能在開局時雙倍下注！", ephemeral=True)
-            return
-        
-        self.game.doubled = True
-        await self.game.cog.update_balance(self.game.ctx.author, -self.game.bet)
-        self.game.player_hand.append(self.game.draw())
-        total = self.game.calc_total(self.game.player_hand)
-        if total > 21:
-            await self.game.finalize("雙倍後爆牌！", win=False)
-        else:
-            await self.dealer_play(interaction, extra="(已雙倍下注)")
-        self.stop()
+        await interaction.response.defer()
+        await self.game.double_current_hand()
 
-    async def dealer_play(self, interaction: discord.Interaction, extra: str = ""):
-        for item in self.children:
-            item.disabled = True
-        await interaction.response.edit_message(view=self)
+    @discord.ui.button(label="分牌", style=discord.ButtonStyle.green, custom_id="split")
+    async def split(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.defer()
+        await self.game.split_current_hand()
 
-        while self.game.calc_total(self.game.dealer_hand) < 17:
-            self.game.dealer_hand.append(self.game.draw())
+    @discord.ui.button(label="買保險", style=discord.ButtonStyle.blurple, custom_id="insurance")
+    async def insurance(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.defer()
+        await self.game.take_insurance()
 
-        p_tot = self.game.calc_total(self.game.player_hand)
-        d_tot = self.game.calc_total(self.game.dealer_hand)
+    @discord.ui.button(label="不買保險", style=discord.ButtonStyle.grey, custom_id="no_insurance")
+    async def no_insurance(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.defer()
+        await self.game.decline_insurance()
 
-        if d_tot > 21 or p_tot > d_tot:
-            payout = self.game.bet * (2 if self.game.doubled else 1)
-            await self.game.finalize(f"你贏了！{extra}", win=True, payout=payout)
-        elif p_tot == d_tot:
-            await self.game.finalize("平手，退回下注。", win=None)
-        else:
-            await self.game.finalize("你輸了。", win=False)
+    @discord.ui.button(label="Even Money", style=discord.ButtonStyle.blurple, custom_id="even_money")
+    async def even_money(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.defer()
+        await self.game.take_even_money()
+
+    @discord.ui.button(label="繼續開牌", style=discord.ButtonStyle.grey, custom_id="decline_even_money")
+    async def decline_even_money(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.defer()
+        await self.game.decline_even_money()
 
     async def on_timeout(self):
         for item in self.children:
             item.disabled = True
-        if self.game.message:
-            await self.game.message.edit(view=None)
-        while self.game.calc_total(self.game.dealer_hand) < 17:
-            self.game.dealer_hand.append(self.game.draw())
-
-        p_tot = self.game.calc_total(self.game.player_hand)
-        d_tot = self.game.calc_total(self.game.dealer_hand)
-
-        if d_tot > 21 or p_tot > d_tot:
-            payout = self.game.bet * (2 if self.game.doubled else 1)
-            await self.game.finalize(f"你贏了！(超時停牌)", win=True, payout=payout)
-        elif p_tot == d_tot:
-            await self.game.finalize("平手，退回下注。", win=None)
-        else:
-            await self.game.finalize("你輸了。", win=False)
-
-        self.game.cleanup()
+        if self.game.message and not self.game._finalized:
+            try:
+                await self.game.message.edit(view=self)
+            except discord.HTTPException:
+                pass
+        await self.game.resolve_timeout()

--- a/casino/casino.py
+++ b/casino/casino.py
@@ -19,6 +19,7 @@ class Casino(commands.Cog, CasinoCommands):
     def __init__(self, bot: Red):
         super().__init__(bot, self)
         self.bot = bot
+        self.casino = self
         self.config = Config.get_conf(self, identifier=1234567890)
         self.active_blackjack_games: dict[int, BlackjackGame] = {}
         self.active_guesssize_games: dict[int, GuessGame] = {}

--- a/casino/command_casino.py
+++ b/casino/command_casino.py
@@ -345,6 +345,9 @@ class CasinoCommands():
         if min_bet <= 0:
             await ctx.send("最低下注金額必須大於 0。")
             return
+        if min_bet % BaccaratRoom.BET_GRANULARITY != 0:
+            await ctx.send(f"最低下注金額必須為 {BaccaratRoom.BET_GRANULARITY:,} 的倍數。")
+            return
 
         try:
             room = BaccaratRoom(ctx=ctx, cog=self, min_bet=min_bet)

--- a/casino/guesssize.py
+++ b/casino/guesssize.py
@@ -63,7 +63,6 @@ class GuessGame:
         numbers = self.player_bet.get("numbers", [])
 
         is_triple = len(unique_values) == 1
-        is_double = 2 in counts.values() and not is_triple
         is_specific_triple = is_triple and dice[0] == number
 
         win_multiplier = 0
@@ -370,7 +369,14 @@ class GuessView(discord.ui.View):
         )
         await interaction.response.send_modal(modal)
 
-    # Example "Straight" button
+    @discord.ui.button(label="指定三骰", style=discord.ButtonStyle.grey, custom_id="three_dice_specific_modal", row=2)
+    async def three_dice_specific_modal(self, interaction: discord.Interaction, button: discord.ui.Button):
+        modal = DiceBetModal(
+            game=self.game, view=self, bet_type_base="three_dice_specific",
+            title="指定三骰", label="輸入三個不同骰子點數", placeholder="例如：1 3 5", requires_three_nums=True
+        )
+        await interaction.response.send_modal(modal)
+
     @discord.ui.button(label="順子", style=discord.ButtonStyle.blurple, custom_id="straight", row=2)
     async def straight(self, interaction: discord.Interaction, button: discord.ui.Button):
         await self.handle_bet_and_finalize(interaction, {"type": "straight"})
@@ -498,19 +504,29 @@ class DiceBetModal(discord.ui.Modal):
 
         if not self.game._finalized:
             log.warning("Finalizing game due to modal error.")
-            await self.game.finalize("因內部錯誤導致遊戲中止，已退款。", -self.game.bet)
+            await self.game.finalize("因內部錯誤導致遊戲中止，已退款。", 0)
 
 
     async def on_timeout(self):
+        if self.game._finalized:
+            return
+
+        self.game._finalized = True
+        if self.game.view_instance:
+            self.game.view_instance.stop()
+
         for item in self.children:
             item.disabled = True
         if self.game.message:
             await self.game.message.edit(view=None)
 
-        refund = self.game.bet
-        await self.game.cog.update_balance(self.game.ctx.author, refund)
-        await self.game.ctx.send(
-            f"{self.game.ctx.author.mention} 遊戲超時，退回下注 {refund} 狗幣。\n"
-            f"目前總狗幣: {int(await self.game.cog.get_balance(self.game.ctx.author)):,}"
-        )
+        active_game = self.game.cog.active_guesssize_games.pop(self.game.ctx.author.id, None)
+        if active_game:
+            refund = self.game.bet
+            await self.game.cog.update_balance(self.game.ctx.author, refund)
+            await self.game.ctx.send(
+                f"{self.game.ctx.author.mention} 遊戲超時，退回下注 {refund} 狗幣。\n"
+                f"目前總狗幣: {int(await self.game.cog.get_balance(self.game.ctx.author)):,}"
+            )
+
         self.game.cog.end_game(self.game.ctx.author.id)

--- a/casino/listener.py
+++ b/casino/listener.py
@@ -31,16 +31,6 @@ class CasinoMessageListener:
             "transfer": ["轉移", "轉帳", "transfer", "v", "打錢"],
         }
 
-    async def _trigger_command_by_keyword(self, message: discord.Message, command_name: str):
-
-        prefix = (await self.bot.get_prefix(message))[0]
-
-        message.content = f"{prefix}{command_name}"
-
-        await self.bot.process_commands(message)
-        
-        log.debug(f"Simulated command trigger: {message.content}")
-
     async def handle_message(self, message: discord.Message):
 
         if message.author.bot or not message.guild:
@@ -106,7 +96,7 @@ class CasinoMessageListener:
                         await message.channel.send("‼️ 轉賬時發生未知錯誤")
 
                 else:
-                    await self._trigger_command_by_keyword(message, command_name)
+                    await ctx.invoke(getattr(self.cog, command_name))
                     log.debug(f"Keyword '{keyword}' triggered simple command '{command_name}'")
 
                 return

--- a/casino/slots.py
+++ b/casino/slots.py
@@ -24,22 +24,22 @@ class SlotGame:
         self.view = SlotView(self)
         self.payouts = {
             "three_same": {
-                ":cherries:": 2,         # 櫻桃
-                ":lemon:": 3,            # 檸檬
-                ":strawberry:": 4,       # 草莓
-                ":tangerine:": 4,        # 橘子
-                ":grapes:": 6,           # 葡萄
-                ":watermelon:": 10,      # 西瓜
-                ":seven:": 40,           # 七
+                ":cherries:": 3,         # 櫻桃
+                ":lemon:": 4,            # 檸檬
+                ":strawberry:": 6,       # 草莓
+                ":tangerine:": 6,        # 橘子
+                ":grapes:": 8,           # 葡萄
+                ":watermelon:": 14,      # 西瓜
+                ":seven:": 56,           # 七
             },
             "two_same": {
                 ":cherries:": 1,         # 櫻桃
-                ":lemon:": 2,            # 檸檬
-                ":strawberry:": 2,       # 草莓
-                ":tangerine:": 2,        # 橘子
-                ":grapes:": 3,           # 葡萄
-                ":watermelon:": 5,       # 西瓜
-                ":seven:": 10,           # 七
+                ":lemon:": 3,            # 檸檬
+                ":strawberry:": 3,       # 草莓
+                ":tangerine:": 3,        # 橘子
+                ":grapes:": 4,           # 葡萄
+                ":watermelon:": 7,       # 西瓜
+                ":seven:": 14,           # 七
             },
         }
         self.emoji_weights = {
@@ -68,7 +68,7 @@ class SlotGame:
         embed.add_field(
             name="🕹️ 遊戲規則",
             value=f"• 單次下注金額: **{self.bet:,}** 籌碼\n"
-                  "• 每次旋轉間隔: 5 秒冷卻\n"
+                  f"• 每次旋轉間隔: {self.spin_cooldown} 秒冷卻\n"
                   "• 中獎組合判定:\n"
                   "  ▸ 3個相同圖示: 獲得對應倍率\n"
                   "  ▸ 2個相同圖示: 獲得次級倍率\n"


### PR DESCRIPTION
## Summary

- Reworked blackjack to use an 8-deck shoe, correct 10-card handling, rounded payouts, split, insurance, and even money.
- Added the missing guesssize specific-three-dice UI and fixed timeout/error refund handling.
- Adjusted slots payouts to target a 5-10% house edge and fixed displayed cooldown text.
- Added baccarat bet granularity so banker commission is calculated consistently.
- Cleaned up casino command/listener state handling.

## Validation

- `python -m py_compile casino\casino.py casino\command_casino.py casino\listener.py casino\blackjack.py casino\guesssize.py casino\slots.py casino\baccarat.py casino\db_casino.py`
- `git diff --cached --check`
- Verified slots house edge remains about 7.247470%.
- Verified blackjack 8-deck size, 10-card value, rounded payout, split, insurance, and even money with local mock checks.